### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,5 +1,8 @@
 name: .NET 10 Console Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Joelbu537/C-Text-Adventure/security/code-scanning/1](https://github.com/Joelbu537/C-Text-Adventure/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block to restrict the `GITHUB_TOKEN` to the minimal scope required. For this workflow, the steps only need to read repository contents (for checkout) and upload artifacts, which do not require broader write permissions such as `contents: write`, `issues: write`, or `pull-requests: write`. Therefore, adding `permissions: contents: read` is sufficient and adheres to the principle of least privilege.

The best way to fix this specific workflow without changing its functionality is to add a root-level `permissions` block just under the workflow `name:` (before `on:`). This will apply to all jobs in the workflow (the single `build` job) since that job does not define its own permissions. Concretely, in `.github/workflows/dotnet-desktop.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: .NET 10 Console Build`). No additional methods, imports, or definitions are needed elsewhere, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
